### PR TITLE
chown after root removes cloud.openshift.com credential

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -889,8 +889,8 @@ Resources:
 
           mkdir /home/lab-user/.docker
           echo ${PullSecret} | base64 -d | tr "'" '"' > /home/lab-user/.docker/config.json
-          chown -R lab-user:lab-user /home/lab-user/.docker
           podman logout --authfile /home/lab-user/.docker/config.json cloud.openshift.com
+          chown -R lab-user:lab-user /home/lab-user/.docker
 
           echo ${PrivateSubnet1} > /home/lab-user/private-subnet-id
           chown -R lab-user:lab-user /home/lab-user/private-subnet-id


### PR DESCRIPTION
mirror-registry-init can't complete now because root ran `podman logout cloud.openshift.com` and took over the credentials of lab-users $HOME/.docker/config.json file

[root@salsa-registry ~]#journalctl --no-pager -n 5 -lu mirror-registry-init
Apr 22 18:23:50 ip-10-0-0-35.us-east-2.compute.internal mirror-registry-init.sh[30360]:         * reading JSON file "/home/lab-user/.docker/config.json": open /home/lab-user/.docker/config.json: permission denied
Apr 22 18:23:50 ip-10-0-0-35.us-east-2.compute.internal systemd[1]: mirror-registry-init.service: Main process exited, code=exited, status=125/n/a
Apr 22 18:23:50 ip-10-0-0-35.us-east-2.compute.internal systemd[1]: mirror-registry-init.service: Failed with result 'exit-code'.
Apr 22 18:23:50 ip-10-0-0-35.us-east-2.compute.internal systemd[1]: Failed to start Configure Mirror Quay on first boot.
Apr 22 18:23:50 ip-10-0-0-35.us-east-2.compute.internal systemd[1]: mirror-registry-init.service: Consumed 2.496s CPU time.