### PR TITLE
updated link for mirror-registry

### DIFF
--- a/content/modules/ROOT/pages/lab02.adoc
+++ b/content/modules/ROOT/pages/lab02.adoc
@@ -116,7 +116,7 @@ sudo cp -v oc-mirror /bin
 
 [.lowside,source,bash,role=execute]
 ----
-curl -L -o mirror-registry.tar.gz https://mirror.openshift.com/pub/openshift-v4/clients/mirror-registry/latest/mirror-registry.tar.gz
+curl -L -o mirror-registry.tar.gz https://mirror.openshift.com/pub/cgw/mirror-registry/latest/mirror-registry-amd64.tar.gz
 ----
 
 * `openshift-install`: The OpenShift Installer


### PR DESCRIPTION
I use this lab quite regularly and this PR is to update the link for the mirror-registry binary which has since changed. 