### PR TITLE
Update ocp4.20 oc mirror v2

### DIFF
--- a/content/antora.yml
+++ b/content/antora.yml
@@ -7,7 +7,7 @@ nav:
 
 asciidoc:
   attributes:
-    openshift_version: 4.20
+    openshift_version: '4.20'
     openshift_channel: stable-4.20
     openshift_min_version: 4.20.8
     openshift_max_version: 4.20.8

--- a/content/modules/ROOT/pages/lab02.adoc
+++ b/content/modules/ROOT/pages/lab02.adoc
@@ -310,7 +310,7 @@ No metadata detected, creating new workspace
 ...  a long, uncomfortable pause ...
 
 info: Mirroring completed in 14m12.12s (52.55MB/s)
-Creating archive /mnt/low-side-data/mirror_seq1_000000.tar
+Creating archive /mnt/low-side-data/mirror_000001.tar
 ----
 
 === Summary

--- a/content/modules/ROOT/pages/lab04.adoc
+++ b/content/modules/ROOT/pages/lab04.adoc
@@ -313,11 +313,11 @@ If you recieve the following error:
 ERROR failed to fetch Metadata: failed to load asset "Install Config": failed to create install config: platform.aws.vpc.subnets: Forbidden: additional subnets [subnet-ID] without tag prefix kubernetes.io/cluster/ are found in vpc vpc-052f1bfee99b414d3 of provided subnets. Please add a tag kubernetes.io/cluster/unmanaged to those subnets to exclude them from cluster installation or explicitly assign roles in the install-config to provided subnets
 ----
 
-Run the following command and insert the subnet id from the error message:
+Run the following command and replace SUBNET_ID with the subnet id from the error message:
 
 [.highside,source,bash,role=execute,subs="attributes"]
 ----
-aws ec2 create-tags --resources <SUBNET_ID> --tags Key=kubernetes.io/cluster/unmanaged,Value=true
+aws ec2 create-tags --resources SUBNET_ID --tags Key=kubernetes.io/cluster/unmanaged,Value=true
 ----
 
 Run the `openshift-install` command again.


### PR DESCRIPTION
Description:

Quoted OpenShift version attributes in antora.yml to prevent YAML from converting 4.20 → 4.2

Escaped <SUBNET_ID> in command examples so it renders correctly



Result:

Versions now render as 4.20

Subnet placeholder is visible in commands